### PR TITLE
Add support for sb-lookup links to message commands

### DIFF
--- a/src/msgcommands/lookupSegments.js
+++ b/src/msgcommands/lookupSegments.js
@@ -14,8 +14,8 @@ module.exports = {
     const searchString = msg.content || searchEmbed.title || searchEmbed.description || "";
     const segmentUUID = findSblookupSegment(searchString);
     // query the video ID from the segment UUID, if one was found
-    const segmentData = segmentUUID !== null ? await getSegmentInfo(segmentUUID) : [];
-    const videoID = segmentData[0]?.videoID ?? findVideoID(searchString);
+    const segmentData = segmentUUID ? await getSegmentInfo(segmentUUID) : null;
+    const videoID = segmentData ? segmentData[0].videoID : findVideoID(searchString);
     if (!videoID) return response(videoIDNotFound);
     // fetch
     const body = await getSkipSegments(videoID, CATEGORIES_STRING);

--- a/src/msgcommands/lookupSegments.js
+++ b/src/msgcommands/lookupSegments.js
@@ -1,6 +1,6 @@
-const { findVideoID } = require("../util/validation.js");
+const { findVideoID, findSblookupSegment } = require("../util/validation.js");
 const { videoIDNotFound } = require("../util/invalidResponse.js");
-const { getSkipSegments } = require("../util/min-api.js");
+const { getSkipSegments, getSegmentInfo } = require("../util/min-api.js");
 const { formatSkipSegments } = require("../util/formatResponse.js");
 const { CATEGORIES_STRING } = require("../util/categories.js");
 
@@ -12,7 +12,10 @@ module.exports = {
     const msg = Object.values(interaction.data.resolved.messages)[0];
     const searchEmbed = msg.embeds[0] || {};
     const searchString = msg.content || searchEmbed.title || searchEmbed.description || "";
-    const videoID = findVideoID(searchString);
+    const segmentUUID = findSblookupSegment(searchString);
+    // query the video ID from the segment UUID, if one was found
+    const segmentData = segmentUUID !== null ? await getSegmentInfo(segmentUUID) : [];
+    const videoID = segmentData[0]?.videoID ?? findVideoID(searchString);
     if (!videoID) return response(videoIDNotFound);
     // fetch
     const body = await getSkipSegments(videoID, CATEGORIES_STRING);

--- a/src/msgcommands/openinsbltnfi.js
+++ b/src/msgcommands/openinsbltnfi.js
@@ -1,4 +1,4 @@
-const { findVideoID } = require("../util/validation.js");
+const { findVideoID, findSblookupSegment } = require("../util/validation.js");
 const { videoIDNotFound } = require("../util/invalidResponse.js");
 
 module.exports = {
@@ -9,12 +9,13 @@ module.exports = {
     const msg = Object.values(interaction.data.resolved.messages)[0];
     const embedTitle = (msg.embeds !== undefined && msg.embeds.length ) ? msg.embeds[0].title : "";
     const searchString = msg.content || embedTitle;
+    const segmentUUID = findSblookupSegment(searchString);
     const videoID = findVideoID(searchString);
-    if (!videoID) return response(videoIDNotFound);
+    if (!segmentUUID && !videoID) return response(videoIDNotFound);
     return response({
       type: 4,
       data: {
-        content: `https://sb.ltn.fi/video/${videoID}/`,
+        content: segmentUUID !== null ? `https://sb.ltn.fi/uuid/${segmentUUID}/` : `https://sb.ltn.fi/video/${videoID}/`,
         flags: 64
       }
     });

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -7,6 +7,8 @@ const userLinkExtract = (str) => str.match(userLinkRegex)[1];
 // segment
 const segmentRegex = new RegExp(/^[a-f0-9]{64,65}$/);
 const segmentStrictCheck = (str) => segmentRegex.test(str);
+const sblookupSegmentRegex = new RegExp(/sb.mchang.xyz\/([a-f0-9]{64,65})/);
+const findSblookupSegment = (str) => sblookupSegmentRegex.test(str) ? str.match(sblookupSegmentRegex)[1] : null;
 // video ID
 const videoRegex = "([0-9A-Za-z_-]{11})"; // group to always be index 1
 const urlVideoRegexp = new RegExp(`(?:v=|/)${videoRegex}(?:$|/$|[?&]t=\\d+$)`);
@@ -32,6 +34,7 @@ module.exports = {
   userLinkExtract,
   // segment
   segmentStrictCheck,
+  findSblookupSegment,
   // videoID
   findVideoID,
   strictVideoID


### PR DESCRIPTION
I've noticed the message commands in sb-slash such as `Open in sb.ltn.fi` and `Lookup Segments` did not work correctly with sb-lookup links (the `https://sb.mchang.xyz/<segment UUID>` links)
*So that's exactly what this pull request fixes.*

I've added a function to `util/validation.js` - `findSblookupSegment()` which handles finding the sb-lookup url and grabbing it's segment UUID, somewhat following the style from the previous code.
I've then used this function in `msgcommands/openinsbltnfi.js` and `msgcommands/lookupSegments.js`.

Both commands prioritize sb-lookup links above video IDs due to the video ID lookup not being very accurate.
The `Open in sb.ltn.fi` command simply returns a `https://sb.ltn.fi/uuid/${segmentUUID}/` link instead of `https://sb.ltn.fi/video/${videoID}/` - sb.ltn.fi handles the rest.
The `Lookup Segments` command has to do an extra API query to get the video ID, then resumes it's previous behaviour.

I've tried testing as much as I can without access to a working development environment - I'm pretty sure the `Open in sb.ltn.fi` changes will work, however I couldn't test the `Lookup Segments` changes at all.