### PR TITLE
Add Next & Previous page buttons to /searchsegments and Lookup Segments

### DIFF
--- a/src/buttons/searchsegments_next.js
+++ b/src/buttons/searchsegments_next.js
@@ -1,0 +1,8 @@
+const { common } = require("./searchsegments_prev.js");
+
+module.exports = {
+  name: "lookupsegment",
+  execute: ({ interaction, response }) => {
+    return common({ interaction, response, offset: 1 });
+  }
+};

--- a/src/buttons/searchsegments_prev.js
+++ b/src/buttons/searchsegments_prev.js
@@ -1,0 +1,34 @@
+const { getSearchSegments } = require("../util/min-api.js");
+const { formatSearchSegments } = require("../util/formatResponse.js");
+const { searchSegmentsComponents } = require("../util/components.js");
+
+const common = async ({ interaction, response, offset }) => {
+  const buttonOverrides = JSON.parse(interaction.message.embeds[0].footer.text);
+  const page = Math.max(0, buttonOverrides.page+offset);
+  const { videoID } = buttonOverrides;
+  delete buttonOverrides.page;
+  delete buttonOverrides.videoID;
+  let paramString = "";
+  for (const [key, value] of Object.entries(buttonOverrides)) {
+    if (value) paramString += `&${key}=${value}`;
+  }
+  // fetch
+  const body = await getSearchSegments(videoID, page, paramString);
+  if (!body) return response(timeoutResponse);
+  const responseTemplate = {
+    type: 7,
+    data: {
+      embeds: [formatSearchSegments(videoID, body, {...buttonOverrides, page, videoID})]
+    }
+  };
+  if (body && JSON.parse(body).segmentCount > 10) responseTemplate.data.components = searchSegmentsComponents(body);
+  return response(responseTemplate);
+};
+
+module.exports = {
+  name: "lookupsegment",
+  execute: ({ interaction, response }) => {
+    return common({ interaction, response, offset: -1 });
+  },
+  common
+};

--- a/src/commands/searchsegments.js
+++ b/src/commands/searchsegments.js
@@ -3,6 +3,7 @@ const { formatSearchSegments } = require("../util/formatResponse.js");
 const { findVideoID } = require("../util/validation.js");
 const { videoIDOption, hideOption, findOption, findOptionString } = require("../util/commandOptions.js");
 const { invalidVideoID, timeoutResponse } = require("../util/invalidResponse.js");
+const { searchSegmentsComponents } = require("../util/components.js");
 const [ INTEGER, BOOLEAN ] = [4, 5];
 
 module.exports = {
@@ -59,10 +60,10 @@ module.exports = {
     const json = findOption(interaction, "json");
     // construct URL with filters
     const filterObj = {
-      minVotes: findOption(interaction, "minVotes"),
-      maxVotes: findOption(interaction, "maxVotes"),
-      minViews: findOption(interaction, "minViews"),
-      maxViews: findOption(interaction, "maxViews"),
+      minVotes: findOption(interaction, "minvotes"),
+      maxVotes: findOption(interaction, "maxvotes"),
+      minViews: findOption(interaction, "minviews"),
+      maxViews: findOption(interaction, "maxviews"),
       locked: findOption(interaction, "locked"),
       hidden: findOption(interaction, "hidden"),
       ignored: findOption(interaction, "ignored")
@@ -85,7 +86,8 @@ module.exports = {
       const stringified = (body === "Not Found" ? body : JSON.stringify(JSON.parse(body), null, 4));
       responseTemplate.data.content = "```json\n"+stringified+"```";
     } else {
-      responseTemplate.data.embeds = [formatSearchSegments(videoID, body)];
+      responseTemplate.data.embeds = [formatSearchSegments(videoID, body, {...filterObj, page, videoID})];
+      if (body && JSON.parse(body).segmentCount > 10) responseTemplate.data.components = searchSegmentsComponents(body);
     }
     return response(responseTemplate);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const commands = ["userinfo", "showoff", "userstats", "me",
   "vip",
   "formatunsubmitted"
 ];
-const buttons = ["lookupuser", "lookupsegment"];
+const buttons = ["lookupuser", "lookupsegment", "searchsegments_next", "searchsegments_prev"];
 const messageCmd = {
   "Lookup Segments": "lookupSegments",
   "Open in sb.ltn.fi": "openinsbltnfi",

--- a/src/msgcommands/lookupSegments.js
+++ b/src/msgcommands/lookupSegments.js
@@ -2,6 +2,7 @@ const { findVideoID, findSblookupSegment } = require("../util/validation.js");
 const { videoIDNotFound } = require("../util/invalidResponse.js");
 const { getSearchSegments, getSegmentInfo } = require("../util/min-api.js");
 const { formatSearchSegments } = require("../util/formatResponse.js");
+const { searchSegmentsComponents } = require("../util/components.js");
 
 module.exports = {
   type: 3, // message command
@@ -21,8 +22,9 @@ module.exports = {
     return response({
       type: 4,
       data: {
-        embeds: [formatSearchSegments(videoID, body)],
-        flags: 64
+        embeds: [formatSearchSegments(videoID, body, {page: 0, videoID})],
+        flags: 64,
+        components: searchSegmentsComponents(body)
       }
     });
   }

--- a/src/util/components.js
+++ b/src/util/components.js
@@ -39,3 +39,35 @@ exports.segmentComponents = (videoID, ephemeral) => {
   if (!ephemeral) components[0].components.push(lookupButton);
   return components;
 };
+
+exports.searchSegmentsComponents = (result) => {
+  const { page, segmentCount } = JSON.parse(result);
+  const lastPage = Math.ceil(segmentCount/10)-1;
+  return [{
+    type: 1,
+    components: [
+      {
+        type: 2,
+        label: "Previous page",
+        style: 2,
+        custom_id: "searchsegments_prev",
+        emoji: {
+          id: null,
+          name: "◀️"
+        },
+        disabled: page <= 0
+      },
+      {
+        type: 2,
+        label: "Next page",
+        style: 2,
+        custom_id: "searchsegments_next",
+        emoji: {
+          id: null,
+          name: "▶️"
+        },
+        disabled: page >= lastPage
+      }
+    ]
+  }];
+};

--- a/src/util/formatResponse.js
+++ b/src/util/formatResponse.js
@@ -230,11 +230,12 @@ const formatSkipSegments = (videoID, result) => {
   return embed;
 };
 
-const formatSearchSegments = (videoID, result) => {
+const formatSearchSegments = (videoID, result, buttonOverrides) => {
   if (result === "Not Found") return segmentsNotFoundEmbed(videoID);
   const embed = emptyVideoEmbed(videoID);
   const parsed = JSON.parse(result);
   embed.description = `**Segments:** ${parsed.segmentCount} | **Page:**: ${parsed.page+1}/${totalPages(parsed.segmentCount)+1}`;
+  embed.footer = {text: JSON.stringify(buttonOverrides || {})};
   const segments = parsed.segments;
   for (const segment of segments) {
     const { startTime, endTime } = segment;


### PR DESCRIPTION
As the title announces, this PR adds Next & Previous page buttons to /searchsegments slash-command and "Lookup Segments" message-command results.

The buttons only appear if the video has more than 10 (1 page) of segments.
The Previous page button becomes disabled when viewing the first page, and the Next page button is disabled when viewing the last page.

The buttons don't send a new message: they update the current one.

This also fixes the small mistake which made filtering of /searchsegments not work