### PR TITLE
Make buttons not appear in "Lookup Segments" message-command when there's only 1 page

### DIFF
--- a/src/commands/searchsegments.js
+++ b/src/commands/searchsegments.js
@@ -87,7 +87,7 @@ module.exports = {
       responseTemplate.data.content = "```json\n"+stringified+"```";
     } else {
       responseTemplate.data.embeds = [formatSearchSegments(videoID, body, {...filterObj, page, videoID})];
-      if (body && JSON.parse(body).segmentCount > 10) responseTemplate.data.components = searchSegmentsComponents(body);
+      responseTemplate.data.components = searchSegmentsComponents(body);
     }
     return response(responseTemplate);
   }

--- a/src/util/components.js
+++ b/src/util/components.js
@@ -41,8 +41,10 @@ exports.segmentComponents = (videoID, ephemeral) => {
 };
 
 exports.searchSegmentsComponents = (result) => {
+  if (!result) return [];
   const { page, segmentCount } = JSON.parse(result);
   const lastPage = Math.ceil(segmentCount/10)-1;
+  if (lastPage == 0) return [];
   return [{
     type: 1,
     components: [


### PR DESCRIPTION
This is done by actually just moving the 1-page check into util/components.js...
which means this has to do less duplicate work (we are no longer parsing the json twice just for the buttons)