### PR TITLE
Add username to /segmentinfo and Lookup Segment button

### DIFF
--- a/src/buttons/lookupsegment.js
+++ b/src/buttons/lookupsegment.js
@@ -2,7 +2,7 @@ const { segmentStrictCheck } = require("../util/validation.js");
 const { formatSegment } = require("../util/formatResponse.js");
 const { segmentComponents } = require("../util/components.js");
 const { invalidSegment, segmentNotFound } = require("../util/invalidResponse.js");
-const { getSegmentInfo } = require("../util/min-api.js");
+const { getSegmentInfo, getUserInfo } = require("../util/min-api.js");
 
 module.exports = {
   name: "lookupsegment",
@@ -12,10 +12,11 @@ module.exports = {
     // fetch
     const parsed = await getSegmentInfo(segmentid);
     if (parsed[0] === null) return response(segmentNotFound);
+    const user = await getUserInfo(parsed[0].userID);
     return response({
       type: 4,
       data: {
-        embeds: [formatSegment(parsed[0])],
+        embeds: [formatSegment(parsed[0], user)],
         components: segmentComponents(parsed[0].videoID, true),
         flags: 64
       }

--- a/src/commands/segmentinfo.js
+++ b/src/commands/segmentinfo.js
@@ -2,7 +2,7 @@ const { segmentStrictCheck } = require("../util/validation.js");
 const { formatSegment } = require("../util/formatResponse.js");
 const { segmentComponents } = require("../util/components.js");
 const { invalidSegment, segmentNotFound, timeoutResponse } = require("../util/invalidResponse.js");
-const { getSegmentInfo, timeout } = require("../util/min-api.js");
+const { getSegmentInfo, getUserInfo, timeout } = require("../util/min-api.js");
 const { hideOption, segmentIDOption, findOption, findOptionString } = require("../util/commandOptions.js");
 
 module.exports = {
@@ -22,10 +22,11 @@ module.exports = {
     const parsed = await Promise.race([getSegmentInfo(segmentid), timeout]);
     if (!parsed) return response(timeoutResponse);
     if (parsed[0] === null) return response(segmentNotFound);
+    const user = await getUserInfo(parsed[0].userID);
     return response({
       type: 4,
       data: {
-        embeds: [formatSegment(parsed[0])],
+        embeds: [formatSegment(parsed[0], user)],
         components: segmentComponents(parsed[0].videoID, false),
         flags: (hide ? 64 : 0)
       }

--- a/src/util/formatResponse.js
+++ b/src/util/formatResponse.js
@@ -110,7 +110,7 @@ const formatUser = (result, submitted) =>
   **Last Submission Time:** ${timeStamp(submitted)}
   `;
 
-const formatSegment = (result) => {
+const formatSegment = (result, user) => {
   const embed = emptyEmbed();
   const { videoID, category, startTime, endTime, UUID } = result;
   const videoLink = videoTimeLink(videoID, startTime, UUID);
@@ -124,6 +124,7 @@ const formatSegment = (result) => {
   **Video Duration:** ${secondsToTime(result.videoDuration)}
   **User ID:** \`${result.userID}\`
   `;
+  if (user && user.userID !== user.userName) embed.description += `**Username:** ${userName(user)}`;
   return embed;
 };
 


### PR DESCRIPTION
As the title announces, this PR adds usernames of the segment submitter to the embeds of `/segmentinfo` slash-commands and "Lookup Segment" buttons on the `/userinfo` slash-command.

As with `/userinfo`, the username will be prefixed with `[VIP]` if they are one (the same code is used)
If the user didn't set a username (userID == userName), it is not shown.