### PR TITLE
Use embeds for /userinfo and /me userinfo

### DIFF
--- a/src/buttons/lookupsegment.js
+++ b/src/buttons/lookupsegment.js
@@ -7,7 +7,8 @@ const { getSegmentInfo } = require("../util/min-api.js");
 module.exports = {
   name: "lookupsegment",
   execute: async ({ interaction, response }) => {
-    const segmentid = interaction.message.content.match(/(?:\*\*Last Submission:\*\*) `([a-f0-9]{64,65})`/)[1];
+    const prevContent = interaction.message.content || interaction.message.embeds[0].description;
+    const segmentid = prevContent.match(/\*\*Last Submission:\*\* <t:\d+:R>\s+`([a-f0-9]{64,65})`/)[1];
     if (!segmentStrictCheck(segmentid)) return response(invalidSegment);
     // fetch
     const parsed = await getSegmentInfo(segmentid);

--- a/src/buttons/lookupuser.js
+++ b/src/buttons/lookupuser.js
@@ -16,7 +16,7 @@ module.exports = {
     return response({
       type: 4,
       data: {
-        content: formatUser(parsedUser, timeSubmitted),
+        embeds: [formatUser(parsedUser, timeSubmitted)],
         components: userComponents(publicid, true),
         flags: 64
       }

--- a/src/commands/me.js
+++ b/src/commands/me.js
@@ -93,7 +93,7 @@ module.exports = {
         return response({
           type: 4,
           data: {
-            content: format.formatUser(res, timeSubmitted),
+            embeds: [format.formatUser(res, timeSubmitted)],
             components: userComponents(SBID, false),
             flags: (hide ? 64 : 0)
           }

--- a/src/commands/userinfo.js
+++ b/src/commands/userinfo.js
@@ -40,7 +40,7 @@ module.exports = {
     return response({
       type: 4,
       data: {
-        content: formatUser(parsedUser, timeSubmitted),
+        embeds: [formatUser(parsedUser, timeSubmitted)],
         components: userComponents(userID, false),
         flags: (hide ? 64 : 0)
       }

--- a/src/util/formatResponse.js
+++ b/src/util/formatResponse.js
@@ -97,18 +97,22 @@ const categoryColour = {
 
 const timeStamp = (time) => `<t:${(""+time).substring(0,10)}:R>`;
 
-const formatUser = (result, submitted) =>
-  `${userName(result)}
-  **Submitted:** ${result.segmentCount.toLocaleString("en-US")}
+const formatUser = (result, submitted) => {
+  const embed = emptyEmbed();
+  embed.title = userName(result);
+  embed.url = `https://sb.ltn.fi/userid/${result.userID}/`;
+  embed.description = `**Submitted:** ${result.segmentCount.toLocaleString("en-US")}
   **Reputation:** ${result.reputation.toFixed(2)}
   **Segment Views:** ${result.viewCount.toLocaleString("en-US")}
   **Time Saved:** ${minutesReadable(result.minutesSaved)}
   **Current Warnings:** ${result.warnings}
   **Ignored Submissions:** ${result.ignoredSegmentCount}
   **Ignored Views:** ${result.ignoredViewCount}
-  **Last Submission:** \`${result.lastSegmentID}\`
-  **Last Submission Time:** ${timeStamp(submitted)}
+  **Last Submission:** ${timeStamp(submitted)}
+  \`${result.lastSegmentID}\`
   `;
+  return embed;
+};
 
 const formatSegment = (result) => {
   const embed = emptyEmbed();


### PR DESCRIPTION
As title announces, this bascially puts all of the information from the current /userinfo implementation and puts it into an embed, making it look more like other commands.
The title also links to sb.ltn.fi.