### PR TITLE
Add support for sb.ltn.fi/uuid/ links in "Lookup Segments" message-commands

### DIFF
--- a/src/msgcommands/lookupSegments.js
+++ b/src/msgcommands/lookupSegments.js
@@ -1,4 +1,4 @@
-const { findVideoID, findSblookupSegment } = require("../util/validation.js");
+const { findVideoID, findSegmentUUID } = require("../util/validation.js");
 const { videoIDNotFound } = require("../util/invalidResponse.js");
 const { getSearchSegments, getSegmentInfo } = require("../util/min-api.js");
 const { formatSearchSegments } = require("../util/formatResponse.js");
@@ -12,7 +12,7 @@ module.exports = {
     const msg = Object.values(interaction.data.resolved.messages)[0];
     const searchEmbed = msg.embeds[0] || {};
     const searchString = msg.content || searchEmbed.title || searchEmbed.description || "";
-    const segmentUUID = findSblookupSegment(searchString);
+    const segmentUUID = findSegmentUUID(searchString);
     // query the video ID from the segment UUID, if one was found
     const segmentData = segmentUUID ? await getSegmentInfo(segmentUUID) : null;
     const videoID = segmentData ? segmentData[0].videoID : findVideoID(searchString);

--- a/src/msgcommands/openinsbltnfi.js
+++ b/src/msgcommands/openinsbltnfi.js
@@ -1,4 +1,4 @@
-const { findVideoID, findSblookupSegment } = require("../util/validation.js");
+const { findVideoID, findSegmentUUID } = require("../util/validation.js");
 const { videoIDNotFound } = require("../util/invalidResponse.js");
 
 module.exports = {
@@ -9,7 +9,7 @@ module.exports = {
     const msg = Object.values(interaction.data.resolved.messages)[0];
     const embedTitle = (msg.embeds !== undefined && msg.embeds.length ) ? msg.embeds[0].title : "";
     const searchString = msg.content || embedTitle;
-    const segmentUUID = findSblookupSegment(searchString);
+    const segmentUUID = findSegmentUUID(searchString);
     const videoID = findVideoID(searchString);
     if (!segmentUUID && !videoID) return response(videoIDNotFound);
     return response({

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -7,8 +7,8 @@ const userLinkExtract = (str) => str.match(userLinkRegex)[1];
 // segment
 const segmentRegex = new RegExp(/^[a-f0-9]{64,65}$/);
 const segmentStrictCheck = (str) => segmentRegex.test(str);
-const sblookupSegmentRegex = new RegExp(/sb.mchang.xyz\/([a-f0-9]{64,65})/);
-const findSblookupSegment = (str) => sblookupSegmentRegex.test(str) ? str.match(sblookupSegmentRegex)[1] : null;
+const segmentLinkRegex = new RegExp(/(?:sb.mchang.xyz|sb.ltn.fi\/uuid)\/([a-f0-9]{64,65})/);
+const findSegmentUUID = (str) => segmentLinkRegex.test(str) ? str.match(segmentLinkRegex)[1] : null;
 // video ID
 const videoRegex = "([0-9A-Za-z_-]{11})"; // group to always be index 1
 const urlVideoRegexp = new RegExp(`(?:v=|/)${videoRegex}(?:$|/$|[?&]t=\\d+$)`);
@@ -34,7 +34,7 @@ module.exports = {
   userLinkExtract,
   // segment
   segmentStrictCheck,
-  findSblookupSegment,
+  findSegmentUUID,
   // videoID
   findVideoID,
   strictVideoID


### PR DESCRIPTION
As title announces, this makes "Lookup Segments" work with sb.ltn.fi/uuid links. This is simply an update to the sb-lookup semgnent link regex, allowing for sb.ltn.fi segment links to be detected with the same function.

I also renamed `findSblookupSegment()` to `findSegmentUUID()`, as it no longer only looks for sb-lookup segments.