### PR TITLE
Fix LookupSegments message-command

### DIFF
--- a/src/msgcommands/lookupSegments.js
+++ b/src/msgcommands/lookupSegments.js
@@ -16,7 +16,7 @@ module.exports = {
     // query the video ID from the segment UUID, if one was found
     const segmentData = segmentUUID ? await getSegmentInfo(segmentUUID) : null;
     const videoID = segmentData?.[0].videoID || findVideoID(searchString);
-    if (!videoID) return response(videoIDNotFound());
+    if (!videoID) return response(videoIDNotFound);
     // fetch
     const subreq = await Promise.race([getSearchSegments(videoID, 0, ""), scheduler.wait(TIMEOUT)]);
     const result = await responseHandler(subreq);

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -5,10 +5,11 @@ const userStrictCheck = (str) => userStrictRegex.test(str);
 const userLinkCheck = (str) => userLinkRegex.test(str);
 const userLinkExtract = (str) => str.match(userLinkRegex)[1];
 // segment
-const segmentRegex = new RegExp(/^[a-f0-9]{64,65}$/);
-const segmentStrictCheck = (str) => segmentRegex.test(str);
-const segmentLinkRegex = new RegExp(/(?:sb.mchang.xyz|sb.ltn.fi\/uuid)\/([a-f0-9]{64,65})/);
-const findSegmentUUID = (str) => segmentLinkRegex.test(str) ? str.match(segmentLinkRegex)[1] : null;
+const segmentRegex = "[a-f0-9]{64,65}";
+const segmentStrictRegex = new RegExp(`^${segmentRegex}$`);
+const segmentStrictCheck = (str) => segmentStrictRegex.test(str);
+const segmentGeneralRegex = new RegExp(`(?:^|\\W)(${segmentRegex})(?:$|\\W)`);
+const findSegmentUUID = (str) => segmentGeneralRegex.test(str) ? str.match(segmentGeneralRegex)[1] : null;
 // video ID
 const videoRegex = "([0-9A-Za-z_-]{11})"; // group to always be index 1
 const urlVideoRegexp = new RegExp(`(?:v=|/|youtu.be/)${videoRegex}(?:|/|[?&]t=\\d+s?)>?(?:\\s|$)`);

--- a/src/util/validation.js
+++ b/src/util/validation.js
@@ -11,7 +11,7 @@ const segmentLinkRegex = new RegExp(/(?:sb.mchang.xyz|sb.ltn.fi\/uuid)\/([a-f0-9
 const findSegmentUUID = (str) => segmentLinkRegex.test(str) ? str.match(segmentLinkRegex)[1] : null;
 // video ID
 const videoRegex = "([0-9A-Za-z_-]{11})"; // group to always be index 1
-const urlVideoRegexp = new RegExp(`(?:v=|/|youtu.be/)${videoRegex}(?:$|/$|[?&]t=\\d+s$|\\s)`);
+const urlVideoRegexp = new RegExp(`(?:v=|/|youtu.be/)${videoRegex}(?:|/|[?&]t=\\d+s?)>?(?:\\s|$)`);
 const onlyVideoRegexp = new RegExp(`^${videoRegex}$`);
 const findVideoID = (str) => {
   if (urlVideoRegexp.test(str)) {


### PR DESCRIPTION
In this PR, I:
* Fixed the LookupSegments message-command crashing when no video ID or segment UUID was found
* Fixed the `findVideoID()` function not recognising the video link when it's embed is hidden by surrounding the link with < >
* Made the `findSegmentUUID()` function find segment UUIDs in more cases than just sb.ltn.fi and sb.mchang.xyz links - Now it should find the UUID when it is surrounded by any non-word character