### PR TITLE
Rewrite & fix /searchsegments button handling code

### DIFF
--- a/src/buttons/searchsegments_prev.js
+++ b/src/buttons/searchsegments_prev.js
@@ -1,8 +1,8 @@
-const { getSearchSegments, responseHandler, TIMEOUT } = require("../util/min-api.js");
-const { formatSearchSegments, segmentsNotFoundEmbed } = require("../util/formatResponse.js");
-const { timeoutResponse } = require("../util/invalidResponse.js");
+const { getSearchSegments, TIMEOUT } = require("../util/min-api.js");
+const { formatSearchSegments } = require("../util/formatResponse.js");
 const { searchSegmentsComponents } = require("../util/components.js");
-const { embedResponse, contentResponse } = require("../util/discordResponse.js");
+const { componentResponse } = require("../util/discordResponse");
+const { handleResponse } = require("../util/handleResponse");
 
 const common = async ({ interaction, response, offset }) => {
   const buttonOverrides = JSON.parse(interaction.message.embeds[0].footer.text);
@@ -14,39 +14,30 @@ const common = async ({ interaction, response, offset }) => {
   for (const [key, value] of Object.entries(buttonOverrides)) {
     if (value) paramString += `&${key}=${value}`;
   }
+  // Determine if the current user is the one who originally used the slash or message-command
+  // If not, respond in a new, hidden message
+  let hide = true;
+  let edit = true;
+  if (!(interaction.message.flags & 64)) {
+    const currentDiscordUserID = interaction.user ? interaction.user.id : interaction.member.user.id;
+    const previousInteraction = interaction.message.interaction;
+    const previousDiscordUserID = previousInteraction.user ? previousInteraction.user.id : previousInteraction.member.user.id;
+    hide = currentDiscordUserID !== previousDiscordUserID;
+    edit = !hide;
+  }
   // fetch
   const subreq = await Promise.race([getSearchSegments(videoID, page, paramString), scheduler.wait(TIMEOUT)]);
-  const result = await responseHandler(subreq);
-  if (result.success) {
-    const responseTemplate = {
-      type: 7,
-      data: {
-        embeds: [formatSearchSegments(videoID, body, {...buttonOverrides, page, videoID})]
-      }
-    };
-    if (body && JSON.parse(body).segmentCount > 10) responseTemplate.data.components = searchSegmentsComponents(body);
-    // Determine if the current user is the one who originally used the slash or message-command
-    // If not, respond in a new, hidden message
-    if (!(interaction.message.flags & 64)) {
-      const currentDiscordUserID = interaction.user ? interaction.user.id : interaction.member.user.id;
-      const previousInteraction = interaction.message.interaction;
-      const previousDiscordUserID = previousInteraction.user ? previousInteraction.user.id : previousInteraction.member.user.id;
-      if (currentDiscordUserID !== previousDiscordUserID) {
-        responseTemplate.type = 4;
-        responseTemplate.data.flags = 64;
-      }
-    }
-    return response(responseTemplate);
-  } else {
-    // error responses
-    if (result.error === "timeout") {
-      return response(timeoutResponse);
-    } else if (result.code === 404 ) {
-      return response(embedResponse(segmentsNotFoundEmbed(videoID), hide));
-    } else {
-      return response(contentResponse(result.error));
-    }
-  }
+  const successFunc = (data) => {
+    const result = componentResponse(
+      formatSearchSegments(videoID, data, {...buttonOverrides, page, videoID}),
+      searchSegmentsComponents(data),
+      hide
+    );
+    result.type = edit ? 7 : 4;
+    return result;
+  };
+  const result = await handleResponse(successFunc, subreq);
+  return response(result);
 };
 
 module.exports = {


### PR DESCRIPTION
I noticed that the buttons on /searchsegments responses broke.
The issue was likely created when deduplicating code for creating responses & making API requests, in commit [146da6b1](https://github.com/mchangrh/sb-slash/commit/146da6b1ac4ea0f54fcaee3e2a4b2023583e4fb5).
I rewrote a bit of the code to use those new helper functions and make the code look closer to the main /searchsegments command handler.