### PR TITLE
make unsubmitted segments playlist distinct

### DIFF
--- a/src/util/formatResponse.js
+++ b/src/util/formatResponse.js
@@ -404,7 +404,7 @@ const formatUnsubmitted = (debugObj) => {
     title: "Unsubmitted Segments",
     description: filtered.map((s) => formatUnsubmittedTemplate(s)).join("\n")
   };
-  embed.description += `\n\n[Playlist](https://www.youtube.com/watch_videos?video_ids=${filtered.map((s) => s.videoID).join(",")})`;
+  embed.description += `\n\n[Playlist](https://www.youtube.com/watch_videos?video_ids=${new Set(filtered.map((s) => s.videoID)).join(",")})`;
   return embed;
 };
 


### PR DESCRIPTION
the playlist does not need a new entry for the same video. one "Submit" button will submit all segments.

this PR was not tested because I was too lazy to set up a dev environment, but I'm confident the change is fine, despite not being that ideal. I didn't have any other idea.