### PR TITLE
Make embed color red when "Server did not respond with a normal response" is shown

### DIFF
--- a/src/util/formatResponse.js
+++ b/src/util/formatResponse.js
@@ -336,6 +336,7 @@ const formatResponseTime = (data) => {
     return embed;
   } catch {
     embed.description = "Server did not respond with a normal response";
+    embed.color = 0xff0000;
     return embed;
   }
 };


### PR DESCRIPTION
Reported [on discord](https://canary.discord.com/channels/603643120093233162/857293053131489350/997559180573560883)