### PR TITLE
Make command descriptions more consistent & fix a typo

### DIFF
--- a/src/commands/lockcategories.js
+++ b/src/commands/lockcategories.js
@@ -7,7 +7,7 @@ const { embedResponse, contentResponse } = require("../util/discordResponse.js")
 
 module.exports = {
   name: "lockcategories",
-  description: "retrieves video lock categories",
+  description: "Retrieve video lock categories",
   options: [
     videoIDRequired,
     hideOption,

--- a/src/commands/lockreason.js
+++ b/src/commands/lockreason.js
@@ -8,7 +8,7 @@ const { embedResponse } = require("../util/discordResponse.js");
 
 module.exports = {
   name: "lockreason",
-  description: "retrieves video lock reason & lock uesrs",
+  description: "Retrieve video lock reason & lock users",
   options: [
     videoIDRequired,
     hideOption

--- a/src/commands/segmentinfo.js
+++ b/src/commands/segmentinfo.js
@@ -9,7 +9,7 @@ const { componentResponse } = require("../util/discordResponse.js");
 
 module.exports = {
   name: "segmentinfo",
-  description: "retrieves segment info",
+  description: "Retrieve segment info",
   options: [
     segmentIDRequired,
     hideOption

--- a/src/commands/userid.js
+++ b/src/commands/userid.js
@@ -6,16 +6,16 @@ const { contentResponse, embedResponse } = require("../util/discordResponse.js")
 
 module.exports = {
   name: "userid",
-  description: "get ID from username",
+  description: "Get ID from username",
   options: [
     {
       name: "username",
-      description: "username",
+      description: "Username",
       type: 3,
       required: true
     }, {
       name: "exact",
-      description: "search for exact username",
+      description: "Search for exact username",
       type: 5,
       required: false
     }, hideOption

--- a/src/commands/userinfo.js
+++ b/src/commands/userinfo.js
@@ -10,7 +10,7 @@ const { componentResponse } = require("../util/discordResponse.js");
 
 module.exports = {
   name: "userinfo",
-  description: "retrieves user info",
+  description: "Retrieve user info",
   options: [
     publicIDOptionOptional,
     userOptionOptional,

--- a/src/commands/userstats.js
+++ b/src/commands/userstats.js
@@ -8,7 +8,7 @@ const { handleResponse } = require("../util/handleResponse.js");
 
 module.exports = {
   name: "userstats",
-  description: "retrieves user statistics",
+  description: "Retrieve user statistics",
   options: [
     publicIDOptionRequired,
     {


### PR DESCRIPTION
Most commands seems to do uppercase and follow similar "grammar rules", but some seem to not so this pr fixes it by making it more consistent in general + it fixes a typo